### PR TITLE
TypeError: Cannot assign to read only property ‘name’ of function

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@aamodtgroup/frontity-contact-form-7",
-  "version": "0.1.4",
+  "version": "0.1.8",
   "description": "Contact Form 7 extension for Frontity theme.",
   "keywords": [
     "Frontity",
@@ -24,8 +24,8 @@
   },
   "author": "Aamodt Group",
   "peerDependencies": {
-    "frontity": "^1.3.1",
-    "@frontity/html2react": "^1.1.11"
+    "frontity": "^1.15.0",
+    "@frontity/html2react": "^1.6.2"
   },
   "publishConfig": {
     "cache": "~/.npm",

--- a/src/processors/cf7HiddenInputs.js
+++ b/src/processors/cf7HiddenInputs.js
@@ -1,4 +1,3 @@
-import { connect } from "frontity";
 import HiddenInput from '../components/HiddenInput';
 
 const cf7HiddenInputs = {
@@ -19,4 +18,4 @@ const cf7HiddenInputs = {
 	}
 };
 
-export default connect( cf7HiddenInputs );
+export default cf7HiddenInputs;

--- a/src/processors/cf7Span.js
+++ b/src/processors/cf7Span.js
@@ -1,4 +1,3 @@
-import { connect } from "frontity";
 import Span from '../components/Span';
 
 const cf7Span = {
@@ -19,4 +18,4 @@ const cf7Span = {
 	}
 };
 
-export default connect( cf7Span );
+export default cf7Span;

--- a/src/processors/cf7Spans.js
+++ b/src/processors/cf7Spans.js
@@ -1,4 +1,3 @@
-import { connect } from "frontity";
 import Span from './../components/Span';
 
 const cf7Spans = {
@@ -10,4 +9,4 @@ const cf7Spans = {
 	}
 };
 
-export default connect( cf7Spans );
+export default cf7Spans;


### PR DESCRIPTION
I noticed that the Span and HiddenInput processors used export default connect(), while the other processors only used export default. So I removed the connect, and it started to work again.